### PR TITLE
Get user from network in correct way

### DIFF
--- a/lastfm2vkstatus.py
+++ b/lastfm2vkstatus.py
@@ -11,7 +11,7 @@ def main():
     network = pylast.LastFMNetwork(api_key=API_KEY, api_secret=API_SECRET,
                                    username=USERNAME, password_hash=pylast.md5(PASSWORD))
 
-    lastfm = pylast.User("", network)
+    lastfm = network.get_user(USERNAME)
 
     # VK init
     vk_session = vk_api.VkApi(token=VK_USER_TOKEN)


### PR DESCRIPTION
closes #2 

Исследуя, в чем причина проблемы, я решил заглянуть на примеры использования библиотеки `pylast`

И [в одном из примеров](https://github.com/hugovk/lastfm-tools/blob/main/nowplaying.py) увидел, что пользователь получается следующим образом:

```
    user = network.get_user(args.user)
```

Я сделал так же в коде данного проекта, заменил стремный `pylast.User(...)` на `network.get_user`, и все заработало — ошибка исчезла.

